### PR TITLE
Removing duplicated Entity.digestMethod definition in lib/entity.js

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -135,20 +135,6 @@ Entity.digestMethod = function (type, fn) {
   };
 };
 
-Entity.digestMethod = function (type, fn) {
-  if ( ! type) throw new EntityError('type is required for digest method definitions');
-  if ( ! fn) throw new EntityError('a function is required for digest method definitions');
-  if ( ! fn.name) throw new EntityError('Anonmyous functions are not allowed in digest method definitions. Please provide a function name');
-  type.prototype[fn.name] = function () {
-    var digestArgs = Array.prototype.slice.call(arguments);
-    digestArgs.unshift(fn.name);
-    Entity.prototype.digest.apply(this, digestArgs);
-
-    var methodArgs = Array.prototype.slice.call(arguments);
-    return fn.apply(this, methodArgs);
-  };
-};
-
 var mergeProperties = new Map();
 
 Entity.mergeProperty = function (type, name, fn) {


### PR DESCRIPTION
Mateo, hi.

I noticed the Entity.digestMethod was defined twice so removed it. Here's a simple PR with the change. All tests pass.

Thank you!